### PR TITLE
Simplify release title and normalize version name

### DIFF
--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -33466,36 +33466,8 @@ async function getNextVersionNumber(client, context, changes) {
   return newVersion;
 }
 
-function createReleaseTitle(newIcons, updatedIcons, removedIcons) {
-  let releaseTitle = 'Publish';
-
-  if (newIcons.length === 1) {
-    releaseTitle += ' 1 new icon';
-  } else if (newIcons.length > 1) {
-    releaseTitle += ` ${newIcons.length} new icons`;
-  }
-
-  if (updatedIcons.length > 0 && newIcons.length > 0) {
-    releaseTitle += ' and';
-  }
-
-  if (updatedIcons.length === 1) {
-    releaseTitle += ' 1 updated icon';
-  } else if (updatedIcons.length > 1) {
-    releaseTitle += ` ${updatedIcons.length} updated icons`;
-  }
-
-  if (removedIcons.length > 0 && newIcons.length + updatedIcons.length > 0) {
-    releaseTitle += ' and';
-  }
-
-  if (removedIcons.length === 1) {
-    releaseTitle += ' 1 removed icon';
-  } else if (removedIcons.length > 1) {
-    releaseTitle += ` ${removedIcons.length} removed icons`;
-  }
-
-  return releaseTitle;
+function createReleaseTitle(newVersion) {
+  return `Release ${newVersion}`;
 }
 
 function createReleaseNotes(newVersion, newIcons, updatedIcons, removedIcons) {
@@ -33503,7 +33475,7 @@ function createReleaseNotes(newVersion, newIcons, updatedIcons, removedIcons) {
     alphaSort({ caseInsensitive: true })(a.name, b.name);
 
   let releaseHeader = '_this Pull Request was automatically generated_\n\n';
-  releaseHeader += `The new version will be: **v${newVersion}**\n`;
+  releaseHeader += `The new version will be: **${newVersion}**\n`;
 
   let releaseNotes = '';
   if (newIcons.length > 0) {
@@ -33605,7 +33577,7 @@ async function makeReleaseNotes(core, client, context) {
     modified: updatedIcons,
     removed: removedIcons,
   });
-  const title = createReleaseTitle(newIcons, updatedIcons, removedIcons);
+  const title = createReleaseTitle(newVersion);
   const notes = createReleaseNotes(
     newVersion,
     newIcons,
@@ -33657,9 +33629,15 @@ async function main(
       core.info('PR review detected; checking if release PR should be merged');
       await mergeOnApprove(core, client, github.context);
       break;
-    case EVENT_DEBUG:
-      core.info((await makeReleaseNotes(core, client, github.context)).notes);
+    case EVENT_DEBUG: {
+      const { title, notes } = await makeReleaseNotes(
+        core,
+        client,
+        github.context,
+      );
+      core.info([title, notes].filter(Boolean).join('\n\n'));
       break;
+    }
     default:
       core.error(`Event '${event}' not supported by the release action`);
   }
@@ -33683,8 +33661,7 @@ async function doMerge(core, client, context, pr) {
   core.info(`Merging #${pr.number}`);
 
   const newVersion = pr.body.split('**')[1];
-  const commitTitle =
-    pr.title.replace('Publish', 'Release') + ` (${newVersion})`;
+  const commitTitle = `Release ${newVersion.replace(/^v/, '')}`;
   const commitMessage = '#' + pr.body.split('#').slice(1).join('#');
 
   await client.rest.pulls.merge({

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -33479,7 +33479,7 @@ function createReleaseNotes(newVersion, newIcons, updatedIcons, removedIcons) {
 
   let releaseNotes = '';
   if (newIcons.length > 0) {
-    releaseNotes += `\n## ${newIcons.length} new ${newIcons.length > 1 ? 'icons' : 'icon'}\n\n`;
+    releaseNotes += `\n### ${newIcons.length} new ${newIcons.length > 1 ? 'icons' : 'icon'}\n\n`;
     for (let newIcon of newIcons.sort(sortAlphabetically)) {
       const prs = prNumbersToString(newIcon.prNumbers);
       const authors = authorsToString(newIcon.authors);
@@ -33488,7 +33488,7 @@ function createReleaseNotes(newVersion, newIcons, updatedIcons, removedIcons) {
   }
 
   if (updatedIcons.length > 0) {
-    releaseNotes += `\n## ${updatedIcons.length} updated ${updatedIcons.length > 1 ? 'icons' : 'icon'}\n\n`;
+    releaseNotes += `\n### ${updatedIcons.length} updated ${updatedIcons.length > 1 ? 'icons' : 'icon'}\n\n`;
     for (let updatedIcon of updatedIcons.sort(sortAlphabetically)) {
       const prs = prNumbersToString(updatedIcon.prNumbers);
       const authors = authorsToString(updatedIcon.authors);
@@ -33497,7 +33497,7 @@ function createReleaseNotes(newVersion, newIcons, updatedIcons, removedIcons) {
   }
 
   if (removedIcons.length > 0) {
-    releaseNotes += `\n## ${removedIcons.length} removed ${removedIcons.length > 1 ? 'icons' : 'icon'}\n\n`;
+    releaseNotes += `\n### ${removedIcons.length} removed ${removedIcons.length > 1 ? 'icons' : 'icon'}\n\n`;
     for (let removedIcon of removedIcons.sort(sortAlphabetically)) {
       const prs = prNumbersToString(removedIcon.prNumbers);
       const authors = authorsToString(removedIcon.authors);

--- a/src/create.js
+++ b/src/create.js
@@ -544,36 +544,8 @@ async function getNextVersionNumber(client, context, changes) {
   return newVersion;
 }
 
-function createReleaseTitle(newIcons, updatedIcons, removedIcons) {
-  let releaseTitle = 'Publish';
-
-  if (newIcons.length === 1) {
-    releaseTitle += ' 1 new icon';
-  } else if (newIcons.length > 1) {
-    releaseTitle += ` ${newIcons.length} new icons`;
-  }
-
-  if (updatedIcons.length > 0 && newIcons.length > 0) {
-    releaseTitle += ' and';
-  }
-
-  if (updatedIcons.length === 1) {
-    releaseTitle += ' 1 updated icon';
-  } else if (updatedIcons.length > 1) {
-    releaseTitle += ` ${updatedIcons.length} updated icons`;
-  }
-
-  if (removedIcons.length > 0 && newIcons.length + updatedIcons.length > 0) {
-    releaseTitle += ' and';
-  }
-
-  if (removedIcons.length === 1) {
-    releaseTitle += ' 1 removed icon';
-  } else if (removedIcons.length > 1) {
-    releaseTitle += ` ${removedIcons.length} removed icons`;
-  }
-
-  return releaseTitle;
+function createReleaseTitle(newVersion) {
+  return `Release ${newVersion}`;
 }
 
 function createReleaseNotes(newVersion, newIcons, updatedIcons, removedIcons) {
@@ -581,7 +553,7 @@ function createReleaseNotes(newVersion, newIcons, updatedIcons, removedIcons) {
     alphaSort({ caseInsensitive: true })(a.name, b.name);
 
   let releaseHeader = '_this Pull Request was automatically generated_\n\n';
-  releaseHeader += `The new version will be: **v${newVersion}**\n`;
+  releaseHeader += `The new version will be: **${newVersion}**\n`;
 
   let releaseNotes = '';
   if (newIcons.length > 0) {
@@ -683,7 +655,7 @@ export async function makeReleaseNotes(core, client, context) {
     modified: updatedIcons,
     removed: removedIcons,
   });
-  const title = createReleaseTitle(newIcons, updatedIcons, removedIcons);
+  const title = createReleaseTitle(newVersion);
   const notes = createReleaseNotes(
     newVersion,
     newIcons,

--- a/src/create.js
+++ b/src/create.js
@@ -557,7 +557,7 @@ function createReleaseNotes(newVersion, newIcons, updatedIcons, removedIcons) {
 
   let releaseNotes = '';
   if (newIcons.length > 0) {
-    releaseNotes += `\n## ${newIcons.length} new ${newIcons.length > 1 ? 'icons' : 'icon'}\n\n`;
+    releaseNotes += `\n### ${newIcons.length} new ${newIcons.length > 1 ? 'icons' : 'icon'}\n\n`;
     for (let newIcon of newIcons.sort(sortAlphabetically)) {
       const prs = prNumbersToString(newIcon.prNumbers);
       const authors = authorsToString(newIcon.authors);
@@ -566,7 +566,7 @@ function createReleaseNotes(newVersion, newIcons, updatedIcons, removedIcons) {
   }
 
   if (updatedIcons.length > 0) {
-    releaseNotes += `\n## ${updatedIcons.length} updated ${updatedIcons.length > 1 ? 'icons' : 'icon'}\n\n`;
+    releaseNotes += `\n### ${updatedIcons.length} updated ${updatedIcons.length > 1 ? 'icons' : 'icon'}\n\n`;
     for (let updatedIcon of updatedIcons.sort(sortAlphabetically)) {
       const prs = prNumbersToString(updatedIcon.prNumbers);
       const authors = authorsToString(updatedIcon.authors);
@@ -575,7 +575,7 @@ function createReleaseNotes(newVersion, newIcons, updatedIcons, removedIcons) {
   }
 
   if (removedIcons.length > 0) {
-    releaseNotes += `\n## ${removedIcons.length} removed ${removedIcons.length > 1 ? 'icons' : 'icon'}\n\n`;
+    releaseNotes += `\n### ${removedIcons.length} removed ${removedIcons.length > 1 ? 'icons' : 'icon'}\n\n`;
     for (let removedIcon of removedIcons.sort(sortAlphabetically)) {
       const prs = prNumbersToString(removedIcon.prNumbers);
       const authors = authorsToString(removedIcon.authors);

--- a/src/main.js
+++ b/src/main.js
@@ -27,9 +27,15 @@ async function main(
       core.info('PR review detected; checking if release PR should be merged');
       await mergeOnApprove(core, client, github.context);
       break;
-    case EVENT_DEBUG:
-      core.info((await makeReleaseNotes(core, client, github.context)).notes);
+    case EVENT_DEBUG: {
+      const { title, notes } = await makeReleaseNotes(
+        core,
+        client,
+        github.context,
+      );
+      core.info([title, notes].filter(Boolean).join('\n\n'));
       break;
+    }
     default:
       core.error(`Event '${event}' not supported by the release action`);
   }

--- a/src/merge.js
+++ b/src/merge.js
@@ -13,8 +13,7 @@ async function doMerge(core, client, context, pr) {
   core.info(`Merging #${pr.number}`);
 
   const newVersion = pr.body.split('**')[1];
-  const commitTitle =
-    pr.title.replace('Publish', 'Release') + ` (${newVersion})`;
+  const commitTitle = `Release ${newVersion.replace(/^v/, '')}`;
   const commitMessage = '#' + pr.body.split('#').slice(1).join('#');
 
   await client.rest.pulls.merge({

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -6,7 +6,7 @@ import { makeRelease } from '../src/create.js';
 const client = new github.getOctokit('token');
 const expectedNotes = `_this Pull Request was automatically generated_
 
-The new version will be: **v2.0.0**
+The new version will be: **2.0.0**
 
 ## 6 new icons
 
@@ -62,7 +62,7 @@ test.each([
       repo: expect.any(String),
       title: expect.any(String),
       body: expect.stringContaining(
-        `The new version will be: **v${expectedVersion}**`,
+        `The new version will be: **${expectedVersion}**`,
       ),
       head: expect.any(String),
       base: expect.any(String),
@@ -71,13 +71,10 @@ test.each([
 });
 
 test.each([
-  ['patch', 'Publish 1 updated icon'],
-  ['add-and-update', 'Publish 2 new icons and 1 updated icon'],
-  ['add-and-remove', 'Publish 2 new icons and 1 removed icon'],
-  [
-    'add-remove-and-update',
-    'Publish 2 new icons and 1 updated icon and 1 removed icon',
-  ],
+  ['patch', 'Release 1.0.1'],
+  ['add-and-update', 'Release 1.1.0'],
+  ['add-and-remove', 'Release 2.0.0'],
+  ['add-remove-and-update', 'Release 2.0.0'],
 ])('correct release title (%s)', async (token, expectedTitle) => {
   expect.assertions(1);
 

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -8,7 +8,7 @@ const expectedNotes = `_this Pull Request was automatically generated_
 
 The new version will be: **2.0.0**
 
-## 6 new icons
+### 6 new icons
 
 - ACM (#513) (@mondeja)
 - bar (#512) (@LitoMore)
@@ -17,7 +17,7 @@ The new version will be: **2.0.0**
 - Pokémon (#514) (@PeterShaggyNoble)
 - WordPress (#510) (@fbernhart)
 
-## 9 updated icons
+### 9 updated icons
 
 - 1Password (#503) (@service-paradis)
 - Abstract (#509) (@service-paradis)
@@ -29,7 +29,7 @@ The new version will be: **2.0.0**
 - Opera (#510) (@fbernhart)
 - Postman (#506) (@LitoMore)
 
-## 1 removed icon
+### 1 removed icon
 
 - Foobar (#515) (@service-paradis)
 `;

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -6,11 +6,14 @@ import * as github from '../__mocks__/@actions/github.js';
 import main from '../src/main.js';
 
 const makeRelease = jest.fn();
+const makeReleaseNotes = jest.fn();
 const mergeOnApprove = jest.fn();
 
-beforeAll(() => {
+beforeEach(() => {
   makeRelease.mockClear();
+  makeReleaseNotes.mockClear();
   mergeOnApprove.mockClear();
+  core.info.mockClear();
 });
 
 test('event "schedule"', async () => {
@@ -27,4 +30,17 @@ test('event "pull_request_review"', async () => {
   github.context.eventName = 'pull_request_review';
   await main(core, github, { mergeOnApprove });
   expect(mergeOnApprove).toHaveBeenCalledTimes(1);
+});
+
+test('event "debug"', async () => {
+  expect.assertions(1);
+
+  github.context.eventName = 'debug';
+  makeReleaseNotes.mockResolvedValue({
+    title: 'Release 1.2.3',
+    notes: 'Release notes',
+  });
+
+  await main(core, github, { makeReleaseNotes });
+  expect(core.info).toHaveBeenCalledWith('Release 1.2.3\n\nRelease notes');
 });

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -9,10 +9,10 @@ const APPROVED = 'approved';
 const CHANGES_REQUESTED = 'changes_requested';
 const COMMENTED = 'commented';
 
-const prTitle = 'Publish 3 new icons an 2 updated icons';
+const prTitle = 'Release 1.4.0';
 const prBody = `_this Pull Request was automatically generated_
 
-The new version will be: **v1.4.0**
+The new version will be: **1.4.0**
 
 # New Icons
 
@@ -49,7 +49,11 @@ test.each(['OWNER', 'MEMBER'])(
     };
 
     await mergeOnApprove(core, client, github.context);
-    expect(client.rest.pulls.merge).toHaveBeenCalled();
+    expect(client.rest.pulls.merge).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commit_title: 'Release 1.4.0',
+      }),
+    );
   },
 );
 


### PR DESCRIPTION
### Changes

- Change generated release PR titles from icon-count wording to version-only wording, e.g. `Release 16.17.0`
- Remove the `v` prefix from the release notes version line, e.g. `The new version will be: **16.17.0**`
- Include the generated release title in `npm run preview` output before the release notes
- Keep merge commit titles normalized to the unprefixed version format
- Update the release description headings level from 2 to 3 for better visual

I've changed the release to version information only, since we already included the release details in the description.